### PR TITLE
🐛 Fixed not checking the node's parent

### DIFF
--- a/typescript-plugin/src/utils/can-be-destructured.ts
+++ b/typescript-plugin/src/utils/can-be-destructured.ts
@@ -25,7 +25,7 @@ export function canBeDestructured(
   const isUnion = type && type.isUnion();
 
   const isContextForbidden =
-    !node ||
+    !node?.parent ||
     contextsKindsWithForbiddenDestructure.indexOf(node.parent.kind) !== -1;
 
   return Boolean(isIdentifier && isObject && !isContextForbidden && !isUnion);


### PR DESCRIPTION
Fix this error:

```
[2022-06-13 16:46:20.613] [exthost] [error] [vscode.typescript-language-features] provider FAILED
[2022-06-13 16:46:20.613] [exthost] [error] Error: <semantic> TypeScript Server Error (4.7.3)
Cannot read properties of undefined (reading 'kind')
TypeError: Cannot read properties of undefined (reading 'kind')
    at Object.canBeDestructured (/Users/aboqasem/.vscode/extensions/tusaeff.vscode-typescript-destructure-plugin-0.0.10/node_modules/typescript-destructure-plugin/dist/plugin.js:155526:67)
    at DestructureInPlace.canBeApplied (/Users/aboqasem/.vscode/extensions/tusaeff.vscode-typescript-destructure-plugin-0.0.10/node_modules/typescript-destructure-plugin/dist/plugin.js:155067:21)
    at /Users/aboqasem/.vscode/extensions/tusaeff.vscode-typescript-destructure-plugin-0.0.10/node_modules/typescript-destructure-plugin/dist/plugin.js:154982:40
    at Array.filter (<anonymous>)
    at Object.getApplicableRefactors (/Users/aboqasem/.vscode/extensions/tusaeff.vscode-typescript-destructure-plugin-0.0.10/node_modules/typescript-destructure-plugin/dist/plugin.js:154982:10)
    at Object.proxy.getApplicableRefactors (/Users/aboqasem/.vscode/extensions/tusaeff.vscode-typescript-destructure-plugin-0.0.10/node_modules/typescript-destructure-plugin/dist/plugin.js:155023:52)
    at IpcIOSession.Session.getApplicableRefactors (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js:176784:53)
    at Session.handlers.ts.Map.ts.getEntries._a.<computed> (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js:175260:61)
    at /Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js:177172:88
    at IpcIOSession.Session.executeWithRequestId (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js:177163:28)
    at IpcIOSession.Session.executeCommand (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js:177172:33)
    at IpcIOSession.Session.onMessage (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js:177198:35)
    at process.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/node_modules/typescript/lib/tsserver.js:179833:31)
    at process.emit (node:events:390:28)
    at emit (node:internal/child_process:917:12)
    at processTicksAndRejections (node:internal/process/task_queues:84:21)
    at Function.create (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/typescript-language-features/dist/extension.js:1:505818)
    at dispatchResponse (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/typescript-language-features/dist/extension.js:1:499666)
    at dispatchMessage (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/typescript-language-features/dist/extension.js:1:498534)
    at ChildProcess.<anonymous> (/Applications/Visual Studio Code.app/Contents/Resources/app/extensions/typescript-language-features/dist/extension.js:1:498019)
    at ChildProcess.emit (node:events:390:28)
    at ChildProcess.emit (node:domain:475:12)
    at emit (node:internal/child_process:917:12)
    at processTicksAndRejections (node:internal/process/task_queues:84:21)
```